### PR TITLE
Rename language server to objc-clangd to fix builtin conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@
 
 Support for Objective-C/C++ in Zed
 
+## Setup
+
+Since Zed has a built-in `clangd` language server, you need to configure your settings to use `objcpp-clangd` for Objective-C files. Add the following to your Zed `settings.json`:
+
+```json
+{
+  "languages": {
+    "Objective-C": {
+      "language_servers": ["objcpp-clangd", "!clangd"]
+    }
+  }
+}
+```
+
+This enables `objcpp-clangd` (provided by this extension) and disables the built-in `clangd` for Objective-C files.
+
 <img width="3440" height="1431" alt="image" src="https://github.com/user-attachments/assets/11e12f7d-9785-404a-bf9c-e1c618b8ee19" />
 
 -----------------------

--- a/README.md
+++ b/README.md
@@ -23,19 +23,32 @@ Support for Objective-C/C++ in Zed
 
 ## Setup
 
-Since Zed has a built-in `clangd` language server, you need to configure your settings to use `objcpp-clangd` for Objective-C files. Add the following to your Zed `settings.json`:
+Since Zed has a built-in `clangd` language server, you need to configure your settings to use `objcpp-clangd` for Objective-C/C++ files. Add the following to your Zed `settings.json`:
 
 ```json
 {
   "languages": {
     "Objective-C": {
       "language_servers": ["objcpp-clangd", "!clangd"]
+    },
+    "Objective-C++": {
+      "language_servers": ["objcpp-clangd", "!clangd"]
     }
   }
 }
 ```
 
-This enables `objcpp-clangd` (provided by this extension) and disables the built-in `clangd` for Objective-C files.
+If Zed doesn't recognize `.m`/`.mm` files as Objective-C, you may also need:
+
+```json
+{
+  "file_types": {
+    "Objective-C": ["m", "mm"]
+  }
+}
+```
+
+This enables `objcpp-clangd` (provided by this extension) and disables the built-in `clangd` for Objective-C/C++ files.
 
 <img width="3440" height="1431" alt="image" src="https://github.com/user-attachments/assets/11e12f7d-9785-404a-bf9c-e1c618b8ee19" />
 

--- a/extension.toml
+++ b/extension.toml
@@ -6,9 +6,9 @@ schema_version = 1
 authors = ["Akzestia <akzestia@gmail.com>"]
 repository = "https://github.com/Akzestia/objcpp"
 
-[language_servers.clangd]
-name = "clangd"
-languages = ["Objective-C"]
+[language_servers.objcpp-clangd]
+name = "objcpp-clangd"
+languages = ["Objective-C", "Objective-C++"]
 
 [grammars.objc]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-objc"

--- a/src/objc.rs
+++ b/src/objc.rs
@@ -39,7 +39,7 @@ impl zed::Extension for ObjcLspExtension {
     ) -> Result<Command> {
         let path = worktree
             .which("clangd")
-            .ok_or_else(|| "clangd must be installed and available in PATH".to_string())?;
+            .ok_or_else(|| "objcpp-clangd: clangd must be installed and available in PATH".to_string())?;
 
         Ok(zed::Command {
             command: path,


### PR DESCRIPTION
 ### Summary

  - Renames the language server from clangd to objc-clangd in extension.toml and updates the error message in src/objc.rs
  - This avoids a conflict with Zed's built-in clangd language server, which was preventing this extension's language server from being used

  ### Test plan

  - Load the extension in Zed and open an Objective-C file
  - Verify objc-clangd appears as the active language server instead of the built-in clangd